### PR TITLE
Conda integration

### DIFF
--- a/backend/elixir/model/resource_model/resource.py
+++ b/backend/elixir/model/resource_model/resource.py
@@ -55,6 +55,10 @@ class Resource(models.Model):
     availability = models.TextField(blank=True, null=True)
     downtime = models.TextField(blank=True, null=True)
 
+    # Information related to the conda channel and conda package
+    conda_channel = models.CharField(max_length=50, null=True)
+    conda_package = models.CharField(max_length=75, null=True)
+    
     def __unicode__(self):
         return unicode(self.name) or u''
 

--- a/frontend/components/toolPage/toolPage.html
+++ b/frontend/components/toolPage/toolPage.html
@@ -7,6 +7,7 @@
 		<div style="padding-left: 40px; padding-right: 40px; padding-top: 20px; padding-bottom: 60px;" class="default-background">
 			<div ng-include="'/components/toolPage/toolPageHeader.html'"></div>
 			<div ng-include="'/components/toolPage/toolPageSummary.html'"></div>
+			<div ng-include="'/components/toolPage/toolPageConda.html'"></div>
 			<div ng-include="'/components/toolPage/toolPageOperation.html'"></div>
 			<div class="row">
 				<div class="col-md-4 col-sm-6" ng-if="software.publication.length > 0" ng-include="'/components/toolPage/toolPagePublications.html'"></div>

--- a/frontend/components/toolPage/toolPageConda.html
+++ b/frontend/components/toolPage/toolPageConda.html
@@ -1,0 +1,4 @@
+<div style="background:#eee; padding:1pc; border-radius:5px">
+    to install with <a href="https://conda.io/docs/user-guide/tasks/manage-pkgs.html">Conda:</a>
+        <div style="margin-left:2.5pc; margin-top:1pc"><code style="color:#666">conda install -c {{ software.conda_channel }} {{ software.conda_package }}</code></div>
+</div>


### PR DESCRIPTION
As discussed, we are working on a simple way of displaying whether a given tool exists on Conda, and if it does, how to easily install it through a command. As such we'd like to add the following changes:

1) Add a visual representation of the conda installation process (the command) bounded by a box on the resource page. That is, we would like to modify the frontend/components/toolpage/toolpage.html file to include this.

2) Add entries within the model, storing whether a recipe exists of the tool on conda, i.e. add a key storing the conda channel of the tool and one that stores the conda package name. As such, we would like to modify the backend/elixir/model/resource_model/resource.py to store these two new keys.