### PR TITLE
hotfix: remove obsolete flags from tool page

### DIFF
--- a/frontend/components/toolPage/toolPageSummary.html
+++ b/frontend/components/toolPage/toolPageSummary.html
@@ -36,19 +36,6 @@
     <span tooltips tooltip-content="Unique tool ID" class="biotools-curie"
         >(biotools:{{software.biotoolsID}})</span
     >
-    <span
-        ><a
-            class="pill-tag-verified"
-            tooltips
-            tooltip-content="This tool ID has been verified by a curator."
-            ng-if="software.validated"
-            href="https://biotools.readthedocs.io/en/latest/what_is_biotools.html#bio-tools-tool-identifiers"
-            target="_blank"
-            ><i class="fa fa-thumbs-up"></i> ID Verified</a
-        ></span
-    >
-
-    <!--<div data-id="{{ software.biotoolsID | lowercase }}" data-widget-type="widget" data-widget-subtypes="widget" data-widget-tooltip-position="left" data-widget-size="64" class="opeb pull-right" style="width: 64px; height: 64px; margin-right: 10px;"></div>-->
 
     <div
         data-widget-tooltip-position="left"
@@ -72,12 +59,6 @@
 <p style="margin-top: -0.5em" ng-show="software.homepage" class="pill-text">
     <a href="{{ ::software.homepage }}" target="_blank" style="font-size: 1.2em"
         >{{ ::software.homepage }}</a
-    >
-    <span class="pill-tag-error-small" ng-if="software.homepage_status == 1"
-        ><i class="fa fa-chain-broken" aria-hidden="true"></i> Temporarily unavailable</span
-    >
-    <span class="pill-tag-error-small" ng-if="software.homepage_status == 2"
-        ><i class="fa fa-chain-broken" aria-hidden="true"></i> Permanently unavailable</span
     >
 </p>
 <!-- Version list -->

--- a/frontend/partials/tool_edit/toolEditSummary.html
+++ b/frontend/partials/tool_edit/toolEditSummary.html
@@ -27,7 +27,6 @@
 						bo-text="error"></label>
 				</div>
 			</div>
-
 			<!-- 	biotoolsID	 -->
 			<div class="form-group" ng-class="{'has-error': registrationErrorPayload.biotoolsID}" ng-if="controller == 'create'">
 				<label class="col-sm-3 control-label" style="position: relative;">
@@ -54,40 +53,6 @@
 					<a class="edit-link" href="">Edit</a>
 				</div>
 			</div>
-
-
-			<!--
-			<div class="form-group" ng-class="{'has-error': registrationErrorPayload.id}">
-				<label class="col-sm-3 control-label" style="position: relative;">
-					<span tooltips tooltip-side="right" tooltip-content="{{Attribute.description.id.description}}">ID</span>
-					<span style="color:#ff0000;position: absolute; right: 5px;"><b>*</b></span>
-				</label>
-				<div class="col-sm-9">
-					<input ng-model="software.id" ng-if="controller == 'update' || newVersion" type="text" class="form-control" placeholder="ID" ng-disabled="true" validate-edit-resource-field>
-					<div class="input-group" ng-if="controller == 'create' && !newVersion">
-						<input ng-model="software.id" name="identifier" ng-change="makeIdURLSafe(software.id)" type="text" class="form-control" placeholder="ID" ng-disabled="autoUpdateId" validate-edit-resource-field>
-						<span class="input-group-btn">
-							<button class="btn btn-default" type="button" ng-click="editIdToggleButtonClick()">
-								<span ng-show="autoUpdateId">Edit</span><i ng-show="!autoUpdateId" class="fa fa-times remove-icon-button"></i>
-							</button>
-						</span>
-					</div>
-					<label class="help-block" ng-repeat="error in form.summaryForm.identifier.errorMessages" bo-text="error"></label>
-					<label ng-show="!registrationErrorPayload.id" class="help-block">Unique identifier of the resource - <a href="" tooltips tooltip-side="bottom" tooltip-content="ID is used in the URL. Once set it can not be changed." tooltip-show-trigger="mousedown" tooltip-hide-trigger="mousedown">more info</a></label>
-				</div>
-			</div> -->
-			<!-- Latest -->
-			<!-- 			<div class="form-group">
-				<label class="col-sm-3 control-label" style="position: relative;"><span>Latest</span></label>
-				<div class="col-sm-9">
-					<select class="form-control select-btn-group" ng-options="item.value as item.text for item in latestOptions" ng-model="software.latest" name="latest" validate-edit-resource-field>
-					</select>
-					<label class="help-block" ng-repeat="error in form.summaryForm.latest.errorMessages" bo-text="error"></label>
-					<label class="help-block">Is this the latest version?</label>
-				</div>
-				<label class="help-block" ng-repeat="error in form.supplementaryForm.latest.errorMessages" bo-text="error"></label>
-			</div> -->
-
 			<!-- 	Description	 -->
 			<div class="form-group" ng-class="{'has-error': registrationErrorPayload.description}">
 				<label class="col-sm-3 control-label"><span tooltips tooltip-side="right"


### PR DESCRIPTION
This PR removes ID verified, temporary unavailable and permanently unavailable flags from the tool pages.